### PR TITLE
Add check if the button is held for the whole 5 seconds

### DIFF
--- a/libs/pinetime_boot/src/pinetime_boot.c
+++ b/libs/pinetime_boot/src/pinetime_boot.c
@@ -97,7 +97,7 @@ void pinetime_boot_init(void) {
       console_printf("Button held for 5 seconds - ignoring\n");  console_flush();
      }
     
-    if(button_samples > (3000 * 64 * 4)) {
+    if(button_samples > (3000 * 64 * 4) && (button_samples < (3000 * 64 * 5)) {
       console_printf("Restoring factory firmware\n");  console_flush();
       restore_factory();
     }


### PR DESCRIPTION
If the button is held down to reboot the watch and not released after the reboot, the device can enter recovery mode unintentionally. This check aims to ignore the button if it is held for the entirety of the 5 second delay, implying it was held before the device started to boot and should be ignored.

I'm not sure if the count will be exactly 3000 * 64 * 5 in this situation, or if there's a better way to address this, or if the secondary condition is needed for the restore_factory if statement... But I made a PR anyway despite a profound lack of certainty!